### PR TITLE
Fix Mini App window title crash on Linux

### DIFF
--- a/Telegram/Resources/bot_webview_shell_html/page.js
+++ b/Telegram/Resources/bot_webview_shell_html/page.js
@@ -277,6 +277,14 @@
 		setMetric('--fullscreen-control-gap', data.fullscreenControlGap);
 	}
 
+	function applyTitle(data) {
+		const visibleTitle = (data && data.title) || '';
+		title.textContent = visibleTitle;
+		document.title = (data && data.nativeTitle)
+			|| visibleTitle
+			|| 'Telegram';
+	}
+
 	function colorForBackground(value) {
 		if (!/^#[0-9a-f]{6}$/i.test(value || '')) {
 			return null;
@@ -997,8 +1005,7 @@
 			applyColors(data && data.colors);
 			applyChrome(data || {});
 			shellState.bottomText = '';
-			title.textContent = (data && data.title) || '';
-			document.title = (data && data.title) || 'Telegram';
+			applyTitle(data);
 			sameOrigin = !!(data && data.sameOrigin);
 			frameUrl = (data && data.url) || 'about:blank';
 			frameOrigin = sameOrigin ? originFromUrl(frameUrl) : '';
@@ -1021,8 +1028,7 @@
 			if (!isNativeToken(token)) {
 				return;
 			}
-			title.textContent = (data && data.title) || '';
-			document.title = (data && data.title) || 'Telegram';
+			applyTitle(data);
 		},
 		setChrome: function(data, token) {
 			if (!isNativeToken(token)) {

--- a/Telegram/SourceFiles/inline_bots/bot_attach_web_view.cpp
+++ b/Telegram/SourceFiles/inline_bots/bot_attach_web_view.cpp
@@ -96,7 +96,6 @@ https://github.com/telegramdesktop/tdesktop/blob/master/LEGAL
 #include "styles/style_window.h"
 
 #include <QSvgRenderer>
-#include <QtGui/QWindow>
 
 namespace InlineBots {
 namespace {
@@ -1504,6 +1503,10 @@ void WebViewInstance::show(ShowArgs &&args) {
 		.url = args.result.url,
 		.storageId = _session->local().resolveStorageIdBots(),
 		.title = std::move(title),
+		.nativeWindowTitle = u"Bot_%1_%2_%3"_q
+			.arg(_bot->id.value)
+			.arg(_bot->session().user()->id.value)
+			.arg(args.title),
 		.titleBadge = std::move(titleBadge),
 		.bottom = rpl::single('@' + _bot->username()),
 		.delegate = static_cast<Ui::BotWebView::Delegate*>(this),
@@ -1572,10 +1575,6 @@ void WebViewInstance::show(ShowArgs &&args) {
 		}, platformButton->lifetime());
 	}
 	started(args.result.queryId);
-	_panel->toastParent()->windowHandle()->setTitle(u"Bot_%1_%2_%3"_q
-		.arg(_bot->id.value)
-		.arg(_bot->session().user()->id.value)
-		.arg(args.title));
 
 	if (const auto strong = PendingActivation.get()) {
 		if (strong == this) {

--- a/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.cpp
@@ -1182,6 +1182,7 @@ Panel::Progress::Progress(QWidget *parent, Fn<QRect()> rect)
 Panel::Panel(Args &&args)
 : _storageId(args.storageId)
 , _delegate(args.delegate)
+, _nativeWindowTitle(std::move(args.nativeWindowTitle))
 , _externalShell(UseExternalBotWebApps())
 , _menuButtons(args.menuButtons)
 , _externalPanelParent(_externalShell ? std::make_unique<RpWidget>() : nullptr)
@@ -1210,14 +1211,19 @@ Panel::Panel(Args &&args)
 	_widget->setInnerSize(st::botWebViewPanelSize, true);
 
 	const auto panel = _widget.get();
-	rpl::duplicate(
-		args.title
-	) | rpl::on_next([=](const QString &title) {
-		const auto value = tr::lng_credits_box_history_entry_miniapp(tr::now)
-			+ u": "_q
-			+ title;
-		panel->window()->setWindowTitle(value);
-	}, panel->lifetime());
+	if (_nativeWindowTitle.isEmpty()) {
+		rpl::duplicate(
+			args.title
+		) | rpl::on_next([=](const QString &title) {
+			const auto value
+				= tr::lng_credits_box_history_entry_miniapp(tr::now)
+				+ u": "_q
+				+ title;
+			panel->window()->setWindowTitle(value);
+		}, panel->lifetime());
+	} else {
+		panel->window()->setWindowTitle(_nativeWindowTitle);
+	}
 
 	const auto params = _delegate->botThemeParams();
 	updateColorOverrides(params);
@@ -1747,6 +1753,7 @@ void Panel::sendExternalShellBootstrap() {
 		{ u"sameOrigin"_q, bool(_sameOrigin) },
 		{ u"initialOrigin"_q, _initialOrigin },
 		{ u"title"_q, _externalTitle },
+		{ u"nativeTitle"_q, _nativeWindowTitle },
 		{ u"metrics"_q, LinuxShell::Metrics() },
 		{ u"colors"_q, LinuxShell::ColorPayload(externalShellColors(params)) },
 		{ u"bottomText"_q, QString() },
@@ -2608,7 +2615,12 @@ void Panel::setTitle(rpl::producer<QString> title) {
 	}
 	std::move(title) | rpl::on_next([=](const QString &title) {
 		_externalTitle = title;
-		sendExternalShellMethod("setTitle", { { u"title"_q, title } });
+		sendExternalShellMethod(
+			"setTitle",
+			{
+				{ u"title"_q, title },
+				{ u"nativeTitle"_q, _nativeWindowTitle },
+			});
 	}, _widget->lifetime());
 }
 

--- a/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.h
+++ b/Telegram/SourceFiles/ui/chat/attach/attach_bot_webview.h
@@ -144,6 +144,7 @@ struct Args {
 	QString url;
 	Webview::StorageId storageId;
 	rpl::producer<QString> title;
+	QString nativeWindowTitle;
 	Ui::TitleBadgeDescriptor titleBadge;
 	rpl::producer<QString> bottom;
 	not_null<Delegate*> delegate;
@@ -323,6 +324,7 @@ private:
 	const not_null<Delegate*> _delegate;
 	QString _externalUrl;
 	QString _externalTitle;
+	QString _nativeWindowTitle;
 	int _externalBlockCount = 0;
 	bool _closeNeedConfirmation = false;
 	bool _hasSettingsButton = false;


### PR DESCRIPTION
## Summary

- fix a SIGSEGV when opening an external Mini App on Linux
- pass Forkgram's existing `Bot_<bot>_<account>_<app>` native title through `BotWebView::Args`
- set the native title on the Qt top-level widget for embedded views and through `document.title` for the external WebKitGTK shell

## Root cause

On Linux, external Mini Apps use a hidden, non-native Qt panel while WebKitGTK owns the real top-level window. `QWidget::windowHandle()` can therefore return null, but `WebViewInstance::show()` dereferenced it unconditionally.

A null check would avoid the crash but drop Forkgram's native window title. The title is now applied through the window-owning path instead.

## Validation

- full Debug build and link with GCC 15 (`DESKTOP_APP_DISABLE_AUTOUPDATE=ON`)
- headless Chromium checks for shell bootstrap, title updates, empty-title fallback, and invalid-token rejection
- external WebKitGTK smoke test on Linux/X11: the Mini App opened normally with no SIGSEGV or crash dump
- verified all `BotWebView::Args` callers and ran `git diff --check`
